### PR TITLE
Add length to string concat

### DIFF
--- a/src/tudu.cc
+++ b/src/tudu.cc
@@ -93,12 +93,12 @@ int main(int argc, char **argv, char *env[])
 	Config config;
 	bool configErr = !config.load(CONFIG_FILE); // the error will be displayed after check args
 	strncpy(file_rc,env[i]+5,119);
-	strcat(file_rc,"/.tudurc");
+	strncat(file_rc,"/.tudurc", 9);
 	config.load(file_rc);
 
 	if (config.getTuduFile() == L"") {
 		strncpy(file_xml,env[i]+5,117);
-		strcat(file_xml,"/.tudu.xml");
+		strncat(file_xml,"/.tudu.xml", 10);
 	} else {
 		wcstombs(file_xml, config.getTuduFile().c_str(), 128);
 	}

--- a/todo.xml
+++ b/todo.xml
@@ -22,7 +22,7 @@ packages.
 data/tudu.1:227
 </text>
 	</todo>
-	<todo done="no" collapse="no">
+	<todo done="yes" collapse="no">
 		<title>dangerous usage of char[]</title>
 		<text>&gt; [src/tudu.cc:96]: (error) Dangerous usage of 'file_rc' (strncpy doesn't always null-terminate it).
 &gt; [src/tudu.cc:101]: (error) Dangerous usage of 'file_xml' (strncpy doesn't always null-terminate it).


### PR DESCRIPTION
strcat is unsafe because a string could end up not null-terminated.
Instead use the safer strncat.
