### PR TITLE
Fix out-of-bounds access

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -267,8 +267,8 @@ void Parser::patt(iToDo& iterator)
 
 Writer::Writer(const char* pathToSave, ToDo& t): todo(t) 
 {
-	strncpy(path, pathToSave, 128);
-	path[128] = '\0';
+	strncpy(path, pathToSave, 255);
+	path[255] = '\0';
 	file.imbue(locale(""));
 }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -57,7 +57,7 @@ private:
 	wofstream file;
 	ToDo& todo;
 	iToDo* i;
-	char path[128];
+	char path[256];
 
 	void _save();
 	void amp(wstring& str);


### PR DESCRIPTION
```
parser.cc:271:2: warning: array index 128 is past the end of the array (which contains 128 elements) [-Warray-bounds]
        path[128] = '\0';
        ^    ~~~
./parser.h:60:2: note: array 'path' declared here
        char path[128];
        ^
```