### PR TITLE
Add a check that index being shuffled isnt at the beginning to avoid segmentation fault. 

### DIFF
--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -42,10 +42,12 @@ void Sched::add(pToDo todo)
 	{
 		if ((i != sched.end()) && ((*i)->sched() == todo->sched()))
 		{
-			for (; ((*i)->sched() == todo->sched()); i++);
-			i--;
-			todo->schedPosition() = (*i)->schedPosition() + 1;
-			i++;
+			if (i != sched.begin()){
+				for (; ((*i)->sched() == todo->sched()); i++);
+				i--;
+				todo->schedPosition() = (*i)->schedPosition() + 1;
+				i++;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
If adding a tasks ABC and DEF and then setting schedules for both to be the same day (e.g.  both tasks due today or tomorrow), the program segmentation faults. 
This code puts a check in to see if the index being references isnt the beginning index before data is shuffled along 